### PR TITLE
Python3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
     - "2.6"
     - "2.7"
+    - "3.3"
+    - "3.4"
 install:
     pip install -r requirements.txt --use-mirrors &&
     pip install .

--- a/raft/client.py
+++ b/raft/client.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import uuid
 
 import msgpack
@@ -20,7 +21,7 @@ class RaftClient(object):
             self.tcp.recv(0.5)
         if not self.tcp.u2c:
             raise NoConnection
-        self.leader = self.tcp.u2c.keys()[0]
+        self.leader = next(iter(self.tcp.u2c.keys()))
 
     def _send(self, rpc, msgid):
         self.tcp.send(rpc, self.leader)
@@ -30,7 +31,7 @@ class RaftClient(object):
         msg = self.msgs[msgid][0]
         if msg['type'] == 'cr_rdr':
             self.leader = msg['leader']
-            print "redirected to %s! %s" % (self.leader, msg['addr'])
+            print("redirected to %s! %s" % (self.leader, msg['addr']))
             self.tcp.connect(msg['addr'])
             del self.msgs[msgid]
             return self._send(rpc, msgid)

--- a/raft/tcp.py
+++ b/raft/tcp.py
@@ -1,7 +1,10 @@
 import socket
 import errno
 import struct
-import thread
+try:
+    import thread
+except ImportError: # for python3
+    import _thread as thread
 import select
 
 from raft.bijectivemap import create_map
@@ -64,7 +67,7 @@ class TCP(object):
 
     def recv(self, timeout=0):
         try:
-            recv, _, _ = select.select(self.c2u.keys(), [], [], timeout)
+            recv, _, _ = select.select(list(self.c2u.keys()), [], [], timeout)
         except select.error as e:
             if e.args[0] == errno.EINTR:
                 return

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ Development Status :: 1 - Planning
 License :: Public Domain
 Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
+Programming Language :: Python :: 3.3
+Programming Language :: Python :: 3.4
 '''
 
 setup(name='py-raft',

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -26,8 +26,8 @@ def test_le():
          3: mle(3, 4)}
     ra = log.RaftLog(a)
     rb = log.RaftLog(b)
-    assert a <= b
-    assert b <= a
+    assert ra <= rb
+    assert rb <= ra
     # terms equal but more commits in b
     a = {1: mle(1, 2),
          2: mle(2, 2),


### PR DESCRIPTION
I added python3 support. Test passed on python 3.3 and 3.4, but 3.4 failed on Travis-ci because it is not supported yet. The test still passes on python2.6 and 2.7, as well. Please include if you like.

Thank you.
