### PR TITLE
Install requires msgpack

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,5 @@ setup(name='py-raft',
       author_email='kurin@delete.org',
       classifiers = filter(None, classifiers.split('\n')),
       package_data={'': ['version.txt']},
-      packages=['raft'])
+      packages=['raft'],
+      install_requires=('msgpack-python'))


### PR DESCRIPTION
Fresh from install on Debian 7:

``` pyhton
>>> from raft import server
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/raft/server.py", line 9, in <module>
    import msgpack
ImportError: No module named msgpack
>>>
```
