### PR TITLE
Sending a response message for append entries in candidate state.

### DIFF
--- a/raft/server.py
+++ b/raft/server.py
@@ -186,7 +186,10 @@ class Server(threading.Thread):
         if not self.valid_peer(uuid):
             return
         if term < self.term:
-            # illegitimate, toss it
+            if term < self.term:
+            # illegitimate, send response so server can step down
+            rpc = self.ae_rpc_reply(self.commitidx, self.term, False)
+            self.send_to_peer(rpc, uuid)
             return
         self.role = 'follower'
         self.handle_msg_follower_ae(msg)

--- a/raft/server.py
+++ b/raft/server.py
@@ -186,7 +186,6 @@ class Server(threading.Thread):
         if not self.valid_peer(uuid):
             return
         if term < self.term:
-            if term < self.term:
             # illegitimate, send response so server can step down
             rpc = self.ae_rpc_reply(self.commitidx, self.term, False)
             self.send_to_peer(rpc, uuid)


### PR DESCRIPTION
Sending a response message for append entries in candidate state when the term from the sender is illegitimate. This might be useful because the stale leader could try again and again if many candidates arise at the same time. (Not a situation that happens often, but it might happen. Might also be useful that every request sends a response and does not silently remove the message)
